### PR TITLE
Add ability to cycle through units

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -18,7 +18,7 @@
     },
     "max_line_length": {
         "name": "max_line_length",
-        "value": 117,
+        "value": 130,
         "level": "warn",
         "limitComments": true
     },

--- a/keymaps/markdown-atom-todo.cson
+++ b/keymaps/markdown-atom-todo.cson
@@ -10,3 +10,4 @@
 'atom-workspace':
   'ctrl-alt-cmd-o': 'markdown-atom-todo:toggle',
   'ctrl-alt-cmd-i': 'markdown-atom-todo:cycle day'
+  'ctrl-alt-cmd-u': 'markdown-atom-todo:cycle units'

--- a/lib/markdown-atom-todo.coffee
+++ b/lib/markdown-atom-todo.coffee
@@ -71,7 +71,7 @@ module.exports = MarkdownAtomTodo =
 
   cycleUnitDisplay: ->
     if @todoMode?
-      options = [null, 'time', 'cal', 'pts']
+      options = [null, 'time', 'pt', 'cal']
       index = options.indexOf(@selectedUnit)
       nextIndex = (index + 1) % options.length
       @displayUnit(options[nextIndex])

--- a/lib/markdown-atom-todo.coffee
+++ b/lib/markdown-atom-todo.coffee
@@ -48,7 +48,6 @@ module.exports = MarkdownAtomTodo =
 
   #TODO: Eventually this should be tracked for each editor.
   toggle: ->
-    console.log "toggle #{@todoMode}"
     @todoMode = !@todoMode
     if @todoMode
       @showTodo()
@@ -56,32 +55,25 @@ module.exports = MarkdownAtomTodo =
       @hideTodo()
 
   highlightDay: (dayKey) ->
-    console.log "highlight #{dayKey}"
     @highlightedDay = dayKey
     @showTodo()
 
   displayUnit: (selectedUnit) ->
-    console.log "display #{selectedUnit}"
     @selectedUnit = selectedUnit
     @showTodo()
 
   cycleDayHighlight: ->
     if @todoMode?
-      console.log "highlight next day. current: #{@highlightedDay}"
       options = [null, 'U', 'M', 'T', 'W', 'R', 'F', 'S']
-
       index = options.indexOf(@highlightedDay)
       nextIndex = (index + 1) % options.length
-      console.log "nextIndex: #{nextIndex}: #{options[nextIndex]}"
       @highlightDay(options[nextIndex])
 
   cycleUnitDisplay: ->
     if @todoMode?
-      console.log "highlight unit display. current: #{@selectedUnit}"
       options = [null, 'time', 'calories', 'points']
       index = options.indexOf(@selectedUnit)
       nextIndex = (index + 1) % options.length
-      console.log "nextIndex: #{nextIndex}: #{options[nextIndex]}"
       @displayUnit(options[nextIndex])
 
   showTodo: ->

--- a/lib/markdown-atom-todo.coffee
+++ b/lib/markdown-atom-todo.coffee
@@ -71,7 +71,7 @@ module.exports = MarkdownAtomTodo =
 
   cycleUnitDisplay: ->
     if @todoMode?
-      options = [null, 'time', 'calories', 'points']
+      options = [null, 'time', 'cal', 'pts']
       index = options.indexOf(@selectedUnit)
       nextIndex = (index + 1) % options.length
       @displayUnit(options[nextIndex])

--- a/lib/markdown-atom-todo.coffee
+++ b/lib/markdown-atom-todo.coffee
@@ -8,7 +8,7 @@ module.exports = MarkdownAtomTodo =
   subscriptions: null
   todoMode: false
   highlightedDay: null
-  selectedUnit: null
+  selectedUnit: 'time'
 
   # Activate method gets called the first time the command is called.
   activate: (state) ->
@@ -27,7 +27,7 @@ module.exports = MarkdownAtomTodo =
     @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:highlight Saturday": => @highlightDay('S')
 
     @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:cycle day": => @cycleDayHighlight()
-    @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:cycle units": => @cycleUnitsDisplay()
+    @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:cycle units": => @cycleUnitDisplay()
 
     # add ability to remove highlight
     @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:clear highlight": => @highlightDay(null)

--- a/lib/markdown-atom-todo.coffee
+++ b/lib/markdown-atom-todo.coffee
@@ -8,6 +8,7 @@ module.exports = MarkdownAtomTodo =
   subscriptions: null
   todoMode: false
   highlightedDay: null
+  selectedUnit: null
 
   # Activate method gets called the first time the command is called.
   activate: (state) ->
@@ -26,6 +27,7 @@ module.exports = MarkdownAtomTodo =
     @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:highlight Saturday": => @highlightDay('S')
 
     @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:cycle day": => @cycleDayHighlight()
+    @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:cycle units": => @cycleUnitsDisplay()
 
     # add ability to remove highlight
     @subscriptions.add atom.commands.add 'atom-workspace', "markdown-atom-todo:clear highlight": => @highlightDay(null)
@@ -58,6 +60,11 @@ module.exports = MarkdownAtomTodo =
     @highlightedDay = dayKey
     @showTodo()
 
+  displayUnit: (selectedUnit) ->
+    console.log "display #{selectedUnit}"
+    @selectedUnit = selectedUnit
+    @showTodo()
+
   cycleDayHighlight: ->
     if @todoMode?
       console.log "highlight next day. current: #{@highlightedDay}"
@@ -67,6 +74,15 @@ module.exports = MarkdownAtomTodo =
       nextIndex = (index + 1) % options.length
       console.log "nextIndex: #{nextIndex}: #{options[nextIndex]}"
       @highlightDay(options[nextIndex])
+
+  cycleUnitDisplay: ->
+    if @todoMode?
+      console.log "highlight unit display. current: #{@selectedUnit}"
+      options = [null, 'time', 'calories', 'points']
+      index = options.indexOf(@selectedUnit)
+      nextIndex = (index + 1) % options.length
+      console.log "nextIndex: #{nextIndex}: #{options[nextIndex]}"
+      @displayUnit(options[nextIndex])
 
   showTodo: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/markdown-atom-todo.coffee
+++ b/lib/markdown-atom-todo.coffee
@@ -94,7 +94,7 @@ module.exports = MarkdownAtomTodo =
       rowText = editor.lineTextForBufferRow(i)
       parser.parseLine(i, rowText)
 
-    decorator.decorateTodo(editor, parser.todoModel, @highlightedDay)
+    decorator.decorateTodo(editor, parser.todoModel, @highlightedDay, @selectedUnit)
 
   hideTodo: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -65,10 +65,8 @@ module.exports = todoDecorator =
     """
     $('<div/>').html(template).contents()[0]
 
-  decorateWeek: (editor, week) ->
+  decorateWeek: (editor, week, selectedUnit) ->
     marker = @createMarker(editor, week.textRange)
-    #TODO: find a better class name.
-    editor.decorateMarker(marker, type: 'highlight', class: "my-line-class")
 
     # Make hours summary
     completedHours = @getDurationString(week.getDoneDuration())
@@ -91,6 +89,9 @@ module.exports = todoDecorator =
     # build the overlay and decorate.
     overlayElement = @createWeekOverlayElement(hourSummary, perDayBreakdown, percentage)
     editor.decorateMarker(marker, type: 'overlay', item: overlayElement)
+
+  createWeekHoursOverlay: (week) ->
+  createWeekUnitOveray: (week, unit) ->
 
   decorateSection: (editor, section, selectedUnit) ->
     console.log("--decorateSection: " + selectedUnit)
@@ -170,9 +171,10 @@ module.exports = todoDecorator =
     @selectedUnit = selectedUnit
     todayString = moment().format('dd')
     isFirstWeek = false
+    #TODO: This probably double calculates collective amounts.
     for week, weekIndex in tree
       isFirstWeek = (weekIndex == 0)
-      @decorateWeek(editor, week)
+      @decorateWeek(editor, week, selectedUnit)
       for section in week.children
         @decorateSection(editor, section, selectedUnit)
         for item in section.children

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -97,7 +97,7 @@ module.exports = todoDecorator =
       return
     else if selectedUnit == 'time'
       overlay = @createSectionHoursOverlay(section)
-    else if selectedUnit in ['pts', 'cal']
+    else if selectedUnit in ['pt', 'cal']
       overlay = @createSectionUnitsOverlay(section, selectedUnit)
 
     if overlay != null

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -101,13 +101,24 @@ module.exports = todoDecorator =
     total = week.getTotalAmount(unit)
     completed = week.getCompletedAmount(unit)
     if !(total == 0 && completed == 0)
-      content = "#{completed}#{unit} / #{total}#{unit}"
+      weekSummary = "#{completed}#{unit} / #{total}#{unit}"
       percentage = total / completed
-
       # build daily summary
-      hourSummary = perDayBreakdown = null
+      totalPerDay = week.getTotalAmountPerDay(unit)
+      completedPerDay = week.getCompletedAmountPerDay(unit)
+      perDayBreakdown = @createUnitDailyBreakdown(totalPerDay, completedPerDay, unit)
 
-      overlayElement = @createWeekOverlayElement(hourSummary, perDayBreakdown, percentage)
+      overlayElement = @createWeekOverlayElement(weekSummary, perDayBreakdown, percentage)
+
+  createUnitDailyBreakdown: (totalPerDay, completedPerDay, unit) ->
+    perDayBreakdown = []
+    for day, index in textConsts.days
+      breakdown =
+        day: day
+        unitString: "#{completedPerDay[index]}#{unit}"
+        percentage: completedPerDay[index] / totalPerDay[index]
+      perDayBreakdown.push(breakdown)
+    perDayBreakdown
 
   decorateSection: (editor, section, selectedUnit) ->
     if selectedUnit == 'time'

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -66,16 +66,24 @@ module.exports = todoDecorator =
     $('<div/>').html(template).contents()[0]
 
   decorateWeek: (editor, week, selectedUnit) ->
-    marker = @createMarker(editor, week.textRange)
+    console.log("--decorateWeek--: " + selectedUnit)
+    if selectedUnit == 'time'
+      overlayElement = @createWeekHoursOverlay(week)
+    else
+      overlayElement = @createWeekUnitOverlay(week, selectedUnit)
 
-    # Make hours summary
+    if overlayElement?
+      marker = @createMarker(editor, week.textRange)
+      editor.decorateMarker(marker, type: 'overlay', item: overlayElement)
+
+  createWeekHoursOverlay: (week) ->
+    # aggregate summary
     completedHours = @getDurationString(week.getDoneDuration())
     totalHours = @getDurationString(week.getTotalDuration())
     hourSummary = "#{completedHours} / #{totalHours}"
-
     percentage = week.getDoneDuration().asSeconds() / week.getTotalDuration().asSeconds()
 
-    # Make per day summary
+    # Daily summary
     perDayBreakdown = []
     perDay = week.getEstimatesPerDay()
     perDayDone = week.getDoneDurationsPerDay()
@@ -88,14 +96,10 @@ module.exports = todoDecorator =
 
     # build the overlay and decorate.
     overlayElement = @createWeekOverlayElement(hourSummary, perDayBreakdown, percentage)
-    editor.decorateMarker(marker, type: 'overlay', item: overlayElement)
 
-  createWeekHoursOverlay: (week) ->
-  createWeekUnitOveray: (week, unit) ->
+  createWeekUnitOverlay: (week, unit) ->
 
   decorateSection: (editor, section, selectedUnit) ->
-    console.log("--decorateSection: " + selectedUnit)
-
     if selectedUnit == 'time'
       overlay = @createSectionHoursOverlay(section)
     else

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -32,7 +32,7 @@ module.exports = todoDecorator =
     for day in perDayBreakdown
       innerText = """
       <span class="daySummary">
-        <span class="day">#{day.day}</span><span class="hours">#{day.durationString}</span>
+        <span class="day">#{day.day}</span><span class="hours">#{day.amountString}</span>
       <span>
       """
       template = template.concat(@makeProgressBlock(innerText, day.percentage))
@@ -40,7 +40,6 @@ module.exports = todoDecorator =
 
 
   createWeekOverlayElement: (hourSummary, perDayBreakdown, percentage) ->
-    testBlock = @makeProgressBlock("hello", .7)
     template = """
     <div class="same-line-overlay">
       <div class="section-estimate">
@@ -90,7 +89,7 @@ module.exports = todoDecorator =
     for day in textConsts.days
       breakdown =
         day: day
-        durationString: @getDurationString(perDay[day])
+        amountString: @getDurationString(perDay[day])
         percentage: perDayDone[day].asSeconds() / perDay[day].asSeconds()
       perDayBreakdown.push(breakdown)
 
@@ -115,7 +114,7 @@ module.exports = todoDecorator =
     for day, index in textConsts.days
       breakdown =
         day: day
-        unitString: "#{completedPerDay[index]}#{unit}"
+        amountString: "#{completedPerDay[index]}#{unit}"
         percentage: completedPerDay[index] / totalPerDay[index]
       perDayBreakdown.push(breakdown)
     perDayBreakdown

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -93,14 +93,14 @@ module.exports = todoDecorator =
     editor.decorateMarker(marker, type: 'overlay', item: overlayElement)
 
   decorateSection: (editor, section, selectedUnit) ->
-    if selectedUnit == null
-      return
-    else if selectedUnit == 'time'
+    console.log("--decorateSection: " + selectedUnit)
+
+    if selectedUnit == 'time'
       overlay = @createSectionHoursOverlay(section)
-    else if selectedUnit in ['pt', 'cal']
+    else
       overlay = @createSectionUnitsOverlay(section, selectedUnit)
 
-    if overlay != null
+    if overlay?
       marker = @createMarker(editor, section.textRange)
       editor.decorateMarker(marker, type: 'overlay', item: overlay)
 
@@ -114,7 +114,7 @@ module.exports = todoDecorator =
   createSectionUnitsOverlay: (section, unit) ->
     total = section.getTotalAmount(unit)
     completed = section.getCompletedAmount(unit)
-    if(total != 0 && completed != 0)
+    if !(total == 0 && completed == 0)
       content = "#{completed}#{unit} / #{total}#{unit}"
       percentage = total / completed
       overlay = @createSectionOverlayElement(content, percentage)

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -94,10 +94,20 @@ module.exports = todoDecorator =
         percentage: perDayDone[day].asSeconds() / perDay[day].asSeconds()
       perDayBreakdown.push(breakdown)
 
-    # build the overlay and decorate.
+    # build the overlay
     overlayElement = @createWeekOverlayElement(hourSummary, perDayBreakdown, percentage)
 
   createWeekUnitOverlay: (week, unit) ->
+    total = week.getTotalAmount(unit)
+    completed = week.getCompletedAmount(unit)
+    if !(total == 0 && completed == 0)
+      content = "#{completed}#{unit} / #{total}#{unit}"
+      percentage = total / completed
+
+      # build daily summary
+      hourSummary = perDayBreakdown = null
+
+      overlayElement = @createWeekOverlayElement(hourSummary, perDayBreakdown, percentage)
 
   decorateSection: (editor, section, selectedUnit) ->
     if selectedUnit == 'time'

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -93,15 +93,12 @@ module.exports = todoDecorator =
     editor.decorateMarker(marker, type: 'overlay', item: overlayElement)
 
   decorateSection: (editor, section, selectedUnit) ->
-
     if selectedUnit == null
       return
     else if selectedUnit == 'time'
       overlay = @createSectionHoursOverlay(section)
-    else if selectedUnit == 'pts'
-      overlay = @createSectionPointsOverlay(section)
-    else if selectedUnit == 'cal'
-      overlay = @createSectionCaloriesOverlay(section)
+    else if selectedUnit in ['pts', 'cal']
+      overlay = @createSectionUnitsOverlay(section, selectedUnit)
 
     if overlay != null
       marker = @createMarker(editor, section.textRange)
@@ -114,15 +111,12 @@ module.exports = todoDecorator =
     percentage = section.estimateDoneDuration.asSeconds() / section.estimateTotalDuration.asSeconds()
     overlay = @createSectionOverlayElement(content, percentage)
 
-  createSectionPointsOverlay: (section) ->
-
-
-  createSectionCaloriesOverlay: (section) ->
-    totalCalories = section.getTotalCalories()
-    completedCalories = section.getCompletedCalories()
-    if(totalCalories != 0 && completedCalories != 0)
-      content = "#{completedCalories}cal / #{totalCalories}cal"
-      percentage = completedCalories / totalCalories
+  createSectionUnitsOverlay: (section, unit) ->
+    total = section.getTotalAmount(unit)
+    completed = section.getCompletedAmount(unit)
+    if(total != 0 && completed != 0)
+      content = "#{completed}#{unit} / #{total}#{unit}"
+      percentage = total / completed
       overlay = @createSectionOverlayElement(content, percentage)
 
   decorateItem: (editor, item, isFirstWeek, todayString, highlightedDay) ->

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -149,8 +149,9 @@ module.exports = todoDecorator =
       editor.decorateMarker(lineMarker, type: 'line', class: "item-today")
 
 
-  decorateTodo: (editor, tree, highlightedDay) ->
+  decorateTodo: (editor, tree, highlightedDay, selectedUnit) ->
     @highlightedDay = highlightedDay
+    @selectedUnit = selectedUnit
     todayString = moment().format('dd')
     isFirstWeek = false
     for week, weekIndex in tree

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -65,7 +65,6 @@ module.exports = todoDecorator =
     $('<div/>').html(template).contents()[0]
 
   decorateWeek: (editor, week, selectedUnit) ->
-    console.log("--decorateWeek--: " + selectedUnit)
     if selectedUnit == 'time'
       overlayElement = @createWeekHoursOverlay(week)
     else

--- a/lib/todo-decorator.coffee
+++ b/lib/todo-decorator.coffee
@@ -92,16 +92,38 @@ module.exports = todoDecorator =
     overlayElement = @createWeekOverlayElement(hourSummary, perDayBreakdown, percentage)
     editor.decorateMarker(marker, type: 'overlay', item: overlayElement)
 
-  decorateSection: (editor, section) ->
-    marker = @createMarker(editor, section.textRange)
+  decorateSection: (editor, section, selectedUnit) ->
 
+    if selectedUnit == null
+      return
+    else if selectedUnit == 'time'
+      overlay = @createSectionHoursOverlay(section)
+    else if selectedUnit == 'pts'
+      overlay = @createSectionPointsOverlay(section)
+    else if selectedUnit == 'cal'
+      overlay = @createSectionCaloriesOverlay(section)
+
+    if overlay != null
+      marker = @createMarker(editor, section.textRange)
+      editor.decorateMarker(marker, type: 'overlay', item: overlay)
+
+  createSectionHoursOverlay: (section) ->
     totalHours = @getDurationString(section.estimateTotalDuration)
     completedHours = @getDurationString(section.estimateDoneDuration)
     content = "#{completedHours} / #{totalHours}"
-
     percentage = section.estimateDoneDuration.asSeconds() / section.estimateTotalDuration.asSeconds()
     overlay = @createSectionOverlayElement(content, percentage)
-    editor.decorateMarker(marker, type: 'overlay', item: overlay)
+
+  createSectionPointsOverlay: (section) ->
+
+
+  createSectionCaloriesOverlay: (section) ->
+    totalCalories = section.getTotalCalories()
+    completedCalories = section.getCompletedCalories()
+    if(totalCalories != 0 && completedCalories != 0)
+      content = "#{completedCalories}cal / #{totalCalories}cal"
+      percentage = completedCalories / totalCalories
+      overlay = @createSectionOverlayElement(content, percentage)
 
   decorateItem: (editor, item, isFirstWeek, todayString, highlightedDay) ->
 
@@ -158,6 +180,6 @@ module.exports = todoDecorator =
       isFirstWeek = (weekIndex == 0)
       @decorateWeek(editor, week)
       for section in week.children
-        @decorateSection(editor, section)
+        @decorateSection(editor, section, selectedUnit)
         for item in section.children
           @decorateItem(editor, item, isFirstWeek, todayString, highlightedDay)

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -1,4 +1,5 @@
 moment = require 'moment'
+_ = require 'lodash'
 textConsts = require './todo-text-consts'
 utils = require './utils'
 
@@ -113,9 +114,9 @@ module.exports =
           @dayCompletedDurations[item.dayString].add(item.estimate.duration)
       @dayCompletedDurations
     getTotalAmount: (unit) ->
-      (item.getAmount(unit) for item in @children).reduce( (p, c) -> p + c)
+      (item.getAmount(unit) for item in @children).reduce(_.add, 0)
     getCompletedAmount: (unit) ->
-      (item.getCompletedAmount(unit) for item in @children).reduce( (p, c) -> p + c)
+      (item.getCompletedAmount(unit) for item in @children).reduce(_.add, 0)
     getTotalAmountPerDay: (unit) ->
       baseAmount = [0, 0, 0, 0, 0, 0, 0]
       for item in @children

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -65,6 +65,11 @@ module.exports =
         duration.add(section.getDoneDuration())
       duration
 
+    getTotalAmount: (unit) ->
+      (section.getTotalAmount(unit) for section in @children).reduce( (p, c) -> p + c)
+    getCompletedAmount: (unit) ->
+      (section.getCompletedAmount(unit) for section in @children).reduce( (p, c) -> p + c)
+
   parseH3Line: (index, text) ->
     title = text.substring(4)
     bufferRowIndex: index

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -46,7 +46,6 @@ module.exports =
         for day in textConsts.days
           @dayDurations[day].add(sectionEstimates[day])
       @dayDurations
-    # TODO: Needs to be completed
     getDoneDurationsPerDay: ->
       #TODO: It's dumb to have to track @dayCompletedDurations. We should be able to make one on the fly.
       for section in @children
@@ -118,7 +117,19 @@ module.exports =
     getCompletedAmount: (unit) ->
       (item.getCompletedAmount(unit) for item in @children).reduce( (p, c) -> p + c)
     getTotalAmountPerDay: (unit) ->
+      baseAmount = [0, 0, 0, 0, 0, 0, 0]
+      for item in @children
+        index = textConsts.days.indexOf(item.dayString)
+        if(index != -1)
+          baseAmount[index] = baseAmount[index] + item.getAmount(unit)
+      baseAmount
     getCompletedAmountPerDay: (unit) ->
+      baseAmount = [0, 0, 0, 0, 0, 0, 0]
+      for item in @children
+        index = textConsts.days.indexOf(item.dayString)
+        if(index != -1)
+          baseAmount[index] = baseAmount[index] + item.getCompletedAmount(unit)
+      baseAmount
 
   parseTodoLine: (rowIndex, text) ->
     doneIndex = text.search(textConsts.regex.doneBadge)

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -98,18 +98,10 @@ module.exports =
         if item.dayString? and item.isDone and item.estimate?
           @dayCompletedDurations[item.dayString].add(item.estimate.duration)
       @dayCompletedDurations
-    getTotalCalories: ->
-      sum = 0
-      for item in @children
-        if item.calories?
-          sum += item.calories.amount
-      sum
-    getCompletedCalories: ->
-      sum = 0
-      for item in @children
-        if item.calories? && item.isDone
-          sum += item.calories.amount
-      sum
+    getTotalAmount: (unit) ->
+      (item.getAmount(unit) for item in @children).reduce( (p, c) -> p + c)
+    getCompletedAmount: (unit) ->
+      (item.getCompletedAmount(unit) for item in @children).reduce( (p, c) -> p + c)
 
   parseTodoLine: (rowIndex, text) ->
     doneIndex = text.search(textConsts.regex.doneBadge)
@@ -138,6 +130,16 @@ module.exports =
     actual: actual #TODO might drop support for this
     points: points
     calories: calories
+    getAmount: (unit) ->
+      switch unit
+        when 'time' then estimate.duration
+        when 'cal' then @calories.amount
+        when 'pts' then @points.amount
+        else 0
+    getCompletedAmount: (unit) ->
+      if @isDone
+        @getAmount(unit)
+      else 0
 
   ignoreLine: (rowIndex, text) ->
 

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -1,5 +1,6 @@
 moment = require 'moment'
 textConsts = require './todo-text-consts'
+utils = require './utils'
 
 module.exports =
   todoModel: []
@@ -72,10 +73,12 @@ module.exports =
 
     getTotalAmountPerDay: (unit) ->
       dailyAmounts = [0, 0, 0, 0, 0, 0, 0]
-      (item.getTotalAmountPerDay(unit) for section in @children).reduce()
+      (section.getTotalAmountPerDay(unit) for section in @children)
+        .reduce(utils.elementSumArray, dailyAmounts)
     getCompletedAmountPerDay: (unit) ->
       dailyAmounts = [0, 0, 0, 0, 0, 0, 0]
-      (item.getTotalAmountPerDay(unit) for section in @children)
+      (section.getCompletedAmountPerDay(unit) for section in @children)
+        .reduce(utils.elementSumArray, dailyAmounts)
 
   parseH3Line: (index, text) ->
     title = text.substring(4)
@@ -114,6 +117,8 @@ module.exports =
       (item.getAmount(unit) for item in @children).reduce( (p, c) -> p + c)
     getCompletedAmount: (unit) ->
       (item.getCompletedAmount(unit) for item in @children).reduce( (p, c) -> p + c)
+    getTotalAmountPerDay: (unit) ->
+    getCompletedAmountPerDay: (unit) ->
 
   parseTodoLine: (rowIndex, text) ->
     doneIndex = text.search(textConsts.regex.doneBadge)

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -70,6 +70,13 @@ module.exports =
     getCompletedAmount: (unit) ->
       (section.getCompletedAmount(unit) for section in @children).reduce( (p, c) -> p + c)
 
+    getTotalAmountPerDay: (unit) ->
+      dailyAmounts = [0, 0, 0, 0, 0, 0, 0]
+      (item.getTotalAmountPerDay(unit) for section in @children).reduce()
+    getCompletedAmountPerDay: (unit) ->
+      dailyAmounts = [0, 0, 0, 0, 0, 0, 0]
+      (item.getTotalAmountPerDay(unit) for section in @children)
+
   parseH3Line: (index, text) ->
     title = text.substring(4)
     bufferRowIndex: index

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -131,10 +131,10 @@ module.exports =
     points: points
     calories: calories
     getAmount: (unit) ->
+      #TODO: This should be generalized
       switch unit
-        when 'time' then estimate.duration
-        when 'cal' then @calories.amount
-        when 'pts' then @points.amount
+        when 'cal' then @calories?.amount || 0
+        when 'pt' then @points?.amount || 0
         else 0
     getCompletedAmount: (unit) ->
       if @isDone

--- a/lib/todo-parser.coffee
+++ b/lib/todo-parser.coffee
@@ -98,6 +98,18 @@ module.exports =
         if item.dayString? and item.isDone and item.estimate?
           @dayCompletedDurations[item.dayString].add(item.estimate.duration)
       @dayCompletedDurations
+    getTotalCalories: ->
+      sum = 0
+      for item in @children
+        if item.calories?
+          sum += item.calories.amount
+      sum
+    getCompletedCalories: ->
+      sum = 0
+      for item in @children
+        if item.calories? && item.isDone
+          sum += item.calories.amount
+      sum
 
   parseTodoLine: (rowIndex, text) ->
     doneIndex = text.search(textConsts.regex.doneBadge)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,0 +1,4 @@
+_ = require 'lodash'
+module.exports =
+  elementSumArray: (a, b) ->
+    _.sum(x) for x in _.zip(a, b)

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "main": "./lib/markdown-atom-todo",
   "version": "0.0.0",
   "description": "A short description of your package",
-  "keywords": [
-  ],
+  "keywords": [],
   "activationCommands": {
     "atom-workspace": "markdown-atom-todo:toggle"
   },
@@ -14,7 +13,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "moment": "~2.10.6",
-    "jquery": "~2.1.4"
+    "jquery": "~2.1.4",
+    "lodash": "^3.10.1",
+    "moment": "~2.10.6"
   }
 }

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -107,7 +107,7 @@ describe 'TodoDecorator', ->
         testBreakDown = decorator.createUnitDailyBreakdown(total, completed, 'pants')
         testDay = testBreakDown[3]
         expect(testDay.day).toEqual('W')
-        expect(testDay.unitString).toEqual('4pants')
+        expect(testDay.amountString).toEqual('4pants')
         expect(testDay.percentage).toEqual(.1)
 
   describe 'section decoration', ->

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -25,23 +25,33 @@ describe 'TodoDecorator', ->
       spyOn(decorator, 'createMarker')
       spyOn(decorator, 'createSectionOverlayElement')
 
+    describe 'decorateWeek', ->
+      beforeEach ->
+
+      it 'does not decorate week when selected unit is null', ->
+      it 'does not decorate week if no overlay element is created', ->
+      it 'decorates week if overlay element is created', ->
+      it 'calls createWeekHoursOverlay if selected unit is time', ->
+      it 'calls createWeekUnitOverlay if selected unit is anything else', ->
+
+
     describe 'decorateSection', ->
       beforeEach ->
         spyOn(decorator, 'createSectionHoursOverlay').andReturn({})
         spyOn(decorator, 'createSectionUnitsOverlay')
 
-      it 'does not create or decorate a marker when selected unit is null', ->
+      it 'does not decorate when selected unit is null', ->
         decorator.decorateSection(mockEditor, mockSection, null)
         expect(decorator.createMarker).not.toHaveBeenCalled()
         expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
 
-      it 'does not create or decorate a marker if no overlay element is created', ->
+      it 'does not decorate if no overlay element is created', ->
         # spy createSectionUnitsOverlay returns nothing, which is what we want to test here
         decorator.decorateSection(mockEditor, mockSection, 'pt')
         expect(decorator.createMarker).not.toHaveBeenCalled()
         expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
 
-      it 'creates and decorates a marker if overlay element is created', ->
+      it 'decorates if overlay element is created', ->
         # spy createSectionHoursOverlay returns something, which is what we want to test here
         decorator.decorateSection(mockEditor, mockSection, 'time')
         expect(decorator.createMarker).toHaveBeenCalled()

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -1,7 +1,7 @@
 decorator = require '../lib/todo-decorator'
 
 describe 'TodoDecorator', ->
-  mockEditor = mockSection = null
+  mockEditor = mockSection = mockWeek = null
 
   beforeEach ->
     mockEditor =
@@ -10,6 +10,8 @@ describe 'TodoDecorator', ->
       textRange: [[0, 1], [0,10]]
       getTotalAmount: ->
       getCompletedAmount: ->
+    mockWeek =
+      textRange: [[0, 1], [0,10]]
 
     spyOn(mockEditor, 'decorateMarker')
 
@@ -19,21 +21,49 @@ describe 'TodoDecorator', ->
   #TODO
   describe 'createMarker', ->
 
-  describe 'section overlays', ->
+  describe 'week decoration', ->
+
+    beforeEach ->
+      spyOn(decorator, 'createMarker')
+      spyOn(decorator, 'createWeekOverlayElement')
+
+    describe 'decorateWeek', ->
+      beforeEach ->
+        spyOn(decorator, 'createWeekHoursOverlay').andReturn({})
+        spyOn(decorator, 'createWeekUnitOverlay')
+
+      it 'does not decorate week when selected unit is null', ->
+        decorator.decorateWeek(mockEditor, mockWeek, null)
+        expect(decorator.createMarker).not.toHaveBeenCalled()
+        expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
+
+      it 'does not decorate week if no overlay element is created', ->
+        # createWeekUnitOverlay spy returns nothing which is what we're testing
+        decorator.decorateWeek(mockEditor, mockWeek, 'pants')
+        expect(decorator.createMarker).not.toHaveBeenCalled()
+        expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
+
+      it 'decorates week if overlay element is created', ->
+        # createWeekHoursOverlay spy returns something which is what we're testing
+        decorator.decorateWeek(mockEditor, mockWeek, 'time')
+        expect(decorator.createMarker).toHaveBeenCalled()
+        expect(mockEditor.decorateMarker).toHaveBeenCalled()
+
+      it 'calls createWeekHoursOverlay if selected unit is time', ->
+        decorator.decorateWeek(mockEditor, mockSection, 'time')
+        expect(decorator.createWeekHoursOverlay).toHaveBeenCalled()
+        expect(decorator.createWeekUnitOverlay).not.toHaveBeenCalled()
+
+      it 'calls createWeekUnitOverlay if selected unit is anything else', ->
+        decorator.decorateWeek(mockEditor, mockSection, 'pt')
+        expect(decorator.createWeekUnitOverlay).toHaveBeenCalled()
+        expect(decorator.createWeekHoursOverlay).not.toHaveBeenCalled()
+
+  describe 'section decoration', ->
 
     beforeEach ->
       spyOn(decorator, 'createMarker')
       spyOn(decorator, 'createSectionOverlayElement')
-
-    describe 'decorateWeek', ->
-      beforeEach ->
-
-      it 'does not decorate week when selected unit is null', ->
-      it 'does not decorate week if no overlay element is created', ->
-      it 'decorates week if overlay element is created', ->
-      it 'calls createWeekHoursOverlay if selected unit is time', ->
-      it 'calls createWeekUnitOverlay if selected unit is anything else', ->
-
 
     describe 'decorateSection', ->
       beforeEach ->
@@ -51,7 +81,7 @@ describe 'TodoDecorator', ->
         expect(decorator.createMarker).not.toHaveBeenCalled()
         expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
 
-      it 'decorates if overlay element is created', ->
+      it 'decorates section if overlay element is created', ->
         # spy createSectionHoursOverlay returns something, which is what we want to test here
         decorator.decorateSection(mockEditor, mockSection, 'time')
         expect(decorator.createMarker).toHaveBeenCalled()
@@ -60,6 +90,7 @@ describe 'TodoDecorator', ->
       it 'calls createSectionHoursOverlay when selected unit is time', ->
         decorator.decorateSection(mockEditor, mockSection, 'time')
         expect(decorator.createSectionHoursOverlay).toHaveBeenCalled()
+        expect(decorator.createSectionUnitsOverlay).not.toHaveBeenCalled()
 
       it 'calls createSectionUnitsOverlay when selected unit is something else', ->
         decorator.decorateSection(mockEditor, mockSection, 'pt')

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -8,8 +8,8 @@ describe 'TodoDecorator', ->
       decorateMarker: ->
     mockSection =
       textRange: [[0, 1], [0,10]]
-      getTotalCalories: ->
-      getCompletedCalories: ->
+      getTotalAmount: ->
+      getCompletedAmount: ->
 
     spyOn(mockEditor, 'decorateMarker')
 
@@ -28,8 +28,7 @@ describe 'TodoDecorator', ->
     describe 'decorateSection', ->
       beforeEach ->
         spyOn(decorator, 'createSectionHoursOverlay')
-        spyOn(decorator, 'createSectionPointsOverlay')
-        spyOn(decorator, 'createSectionCaloriesOverlay')
+        spyOn(decorator, 'createSectionUnitsOverlay')
 
       it 'does not create or decorate a marker when selected unit is null', ->
         decorator.decorateSection(mockEditor, mockSection, null)
@@ -40,35 +39,35 @@ describe 'TodoDecorator', ->
         decorator.decorateSection(mockEditor, mockSection, 'time')
         expect(decorator.createSectionHoursOverlay).toHaveBeenCalled()
 
-      it 'calls createSectionPointsOverlay when selected unit is pts', ->
+      it 'calls createSectionUnitsOverlay when selected unit is pts', ->
         decorator.decorateSection(mockEditor, mockSection, 'pts')
-        expect(decorator.createSectionPointsOverlay).toHaveBeenCalled()
+        expect(decorator.createSectionUnitsOverlay).toHaveBeenCalled()
 
-      it 'calls createSectionCaloriesOverlay when selected unit is cal', ->
+      it 'calls createSectionUnitsOverlay when selected unit is cal', ->
         decorator.decorateSection(mockEditor, mockSection, 'cal')
-        expect(decorator.createSectionCaloriesOverlay).toHaveBeenCalled()
+        expect(decorator.createSectionUnitsOverlay).toHaveBeenCalled()
 
     describe 'createSectionHoursOverlay', ->
     describe 'createSectionPointsOverlay', ->
 
-    describe 'createSectionCaloriesOverlay', ->
-      it 'calls section.getTotalCalories and section.getCompletedCalories', ->
-        spyOn(mockSection, 'getTotalCalories')
-        spyOn(mockSection, 'getCompletedCalories')
-        decorator.createSectionCaloriesOverlay(mockSection)
-        expect(mockSection.getTotalCalories).toHaveBeenCalled()
-        expect(mockSection.getCompletedCalories).toHaveBeenCalled()
+    describe 'createSectionUnitsOverlay', ->
+      it 'calls section.getTotalAmount and section.getCompletedAmount', ->
+        spyOn(mockSection, 'getTotalAmount')
+        spyOn(mockSection, 'getCompletedAmount')
+        decorator.createSectionUnitsOverlay(mockSection, 'cal')
+        expect(mockSection.getTotalAmount).toHaveBeenCalledWith('cal')
+        expect(mockSection.getCompletedAmount).toHaveBeenCalledWith('cal')
 
-      it 'creates an overlayElement if the section has calories', ->
-        spyOn(mockSection, 'getTotalCalories').andReturn(2)
-        spyOn(mockSection, 'getCompletedCalories').andReturn(1)
-        decorator.createSectionCaloriesOverlay(mockSection)
+      it 'creates an overlayElement if the section has amount of requested unit', ->
+        spyOn(mockSection, 'getTotalAmount').andReturn(2)
+        spyOn(mockSection, 'getCompletedAmount').andReturn(1)
+        decorator.createSectionUnitsOverlay(mockSection, 'cal')
         expect(decorator.createSectionOverlayElement).toHaveBeenCalled()
 
-      it 'does not create an overlayElement if the section has no calories', ->
-        spyOn(mockSection, 'getTotalCalories').andReturn(0)
-        spyOn(mockSection, 'getCompletedCalories').andReturn(0)
-        decorator.createSectionCaloriesOverlay(mockSection)
+      it 'does not create an overlayElement if the section has no amount of requested unit', ->
+        spyOn(mockSection, 'getTotalAmount').andReturn(0)
+        spyOn(mockSection, 'getCompletedAmount').andReturn(0)
+        decorator.createSectionUnitsOverlay(mockSection)
         expect(decorator.createSectionOverlayElement).not.toHaveBeenCalled()
 
 

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -1,12 +1,76 @@
 decorator = require '../lib/todo-decorator'
 
 describe 'TodoDecorator', ->
+  mockEditor = mockSection = null
+
+  beforeEach ->
+    mockEditor =
+      decorateMarker: ->
+    mockSection =
+      textRange: [[0, 1], [0,10]]
+      getTotalCalories: ->
+      getCompletedCalories: ->
+
+    spyOn(mockEditor, 'decorateMarker')
 
   #TODO
   describe 'destroyMarkers', ->
 
   #TODO
   describe 'createMarker', ->
+
+  describe 'section overlays', ->
+
+    beforeEach ->
+      spyOn(decorator, 'createMarker')
+      spyOn(decorator, 'createSectionOverlayElement')
+
+    describe 'decorateSection', ->
+      beforeEach ->
+        spyOn(decorator, 'createSectionHoursOverlay')
+        spyOn(decorator, 'createSectionPointsOverlay')
+        spyOn(decorator, 'createSectionCaloriesOverlay')
+
+      it 'does not create or decorate a marker when selected unit is null', ->
+        decorator.decorateSection(mockEditor, mockSection, null)
+        expect(decorator.createMarker).not.toHaveBeenCalled()
+        expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
+
+      it 'calls createSectionHoursOverlay when selected unit is time', ->
+        decorator.decorateSection(mockEditor, mockSection, 'time')
+        expect(decorator.createSectionHoursOverlay).toHaveBeenCalled()
+
+      it 'calls createSectionPointsOverlay when selected unit is pts', ->
+        decorator.decorateSection(mockEditor, mockSection, 'pts')
+        expect(decorator.createSectionPointsOverlay).toHaveBeenCalled()
+
+      it 'calls createSectionCaloriesOverlay when selected unit is cal', ->
+        decorator.decorateSection(mockEditor, mockSection, 'cal')
+        expect(decorator.createSectionCaloriesOverlay).toHaveBeenCalled()
+
+    describe 'createSectionHoursOverlay', ->
+    describe 'createSectionPointsOverlay', ->
+
+    describe 'createSectionCaloriesOverlay', ->
+      it 'calls section.getTotalCalories and section.getCompletedCalories', ->
+        spyOn(mockSection, 'getTotalCalories')
+        spyOn(mockSection, 'getCompletedCalories')
+        decorator.createSectionCaloriesOverlay(mockSection)
+        expect(mockSection.getTotalCalories).toHaveBeenCalled()
+        expect(mockSection.getCompletedCalories).toHaveBeenCalled()
+
+      it 'creates an overlayElement if the section has calories', ->
+        spyOn(mockSection, 'getTotalCalories').andReturn(2)
+        spyOn(mockSection, 'getCompletedCalories').andReturn(1)
+        decorator.createSectionCaloriesOverlay(mockSection)
+        expect(decorator.createSectionOverlayElement).toHaveBeenCalled()
+
+      it 'does not create an overlayElement if the section has no calories', ->
+        spyOn(mockSection, 'getTotalCalories').andReturn(0)
+        spyOn(mockSection, 'getCompletedCalories').andReturn(0)
+        decorator.createSectionCaloriesOverlay(mockSection)
+        expect(decorator.createSectionOverlayElement).not.toHaveBeenCalled()
+
 
   #TODO
   describe 'decorateTodo', ->

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -1,4 +1,4 @@
-renderer = require '../lib/todo-decorator'
+decorator = require '../lib/todo-decorator'
 
 describe 'TodoDecorator', ->
 
@@ -10,3 +10,34 @@ describe 'TodoDecorator', ->
 
   #TODO
   describe 'decorateTodo', ->
+    mockTree = moment = null
+
+    beforeEach ->
+      mockTree = [
+        children: [
+          children: [1]
+        ]
+      ]
+
+      spyOn(decorator, 'decorateWeek')
+      spyOn(decorator, 'decorateSection')
+      spyOn(decorator, 'decorateItem')
+      oldDate = Date
+      spyOn(window, 'Date').andCallFake( ->
+        testDate = new oldDate(1995, 12, 17) #This is a wednesday
+      )
+
+    it 'keeps highlightedDay parameter', ->
+      decorator.decorateTodo(null, mockTree, 'highlightDay', null)
+      expect(decorator.highlightedDay).toEqual('highlightDay')
+
+    it 'keeps selectedUnit parameter', ->
+      decorator.decorateTodo(null, mockTree, null, 'selectedUnit')
+      expect(decorator.selectedUnit).toEqual('selectedUnit')
+
+    it 'calls @decorateItem with todayString', ->
+      decorator.decorateTodo(null, mockTree, null, null)
+      expect(decorator.decorateItem).toHaveBeenCalledWith(null, 1, true, "We", null)
+
+    it 'calls @decorateWeek with params editor and week params', ->
+    it 'calls @decorateSection with editor and section params', ->

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -6,12 +6,16 @@ describe 'TodoDecorator', ->
   beforeEach ->
     mockEditor =
       decorateMarker: ->
+
     mockSection =
       textRange: [[0, 1], [0,10]]
       getTotalAmount: ->
       getCompletedAmount: ->
+
     mockWeek =
       textRange: [[0, 1], [0,10]]
+      getTotalAmount: ->
+      getCompletedAmount: ->
 
     spyOn(mockEditor, 'decorateMarker')
 
@@ -59,6 +63,28 @@ describe 'TodoDecorator', ->
         expect(decorator.createWeekUnitOverlay).toHaveBeenCalled()
         expect(decorator.createWeekHoursOverlay).not.toHaveBeenCalled()
 
+    describe 'createWeekHoursOverlay', ->
+
+    describe 'createWeekUnitOverlay', ->
+      it 'calls week.getTotalAmount and section.getCompletedAmount', ->
+        spyOn(mockWeek, 'getTotalAmount')
+        spyOn(mockWeek, 'getCompletedAmount')
+        decorator.createWeekUnitOverlay(mockWeek, 'cal')
+        expect(mockWeek.getTotalAmount).toHaveBeenCalledWith('cal')
+        expect(mockWeek.getCompletedAmount).toHaveBeenCalledWith('cal')
+
+      it 'creates an overlayElement if the section has amount of requested unit', ->
+        spyOn(mockWeek, 'getTotalAmount').andReturn(2)
+        spyOn(mockWeek, 'getCompletedAmount').andReturn(1)
+        decorator.createWeekUnitOverlay(mockWeek, 'cal')
+        expect(decorator.createWeekOverlayElement).toHaveBeenCalled()
+
+      it 'does not create an overlayElement if the section has no amount of requested unit', ->
+        spyOn(mockWeek, 'getTotalAmount').andReturn(0)
+        spyOn(mockWeek, 'getCompletedAmount').andReturn(0)
+        decorator.createWeekUnitOverlay(mockWeek, 'cal')
+        expect(decorator.createWeekOverlayElement).not.toHaveBeenCalled()
+
   describe 'section decoration', ->
 
     beforeEach ->
@@ -98,7 +124,6 @@ describe 'TodoDecorator', ->
         expect(decorator.createSectionHoursOverlay).not.toHaveBeenCalled()
 
     describe 'createSectionHoursOverlay', ->
-    describe 'createSectionPointsOverlay', ->
 
     describe 'createSectionUnitsOverlay', ->
       it 'calls section.getTotalAmount and section.getCompletedAmount', ->

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -16,6 +16,8 @@ describe 'TodoDecorator', ->
       textRange: [[0, 1], [0,10]]
       getTotalAmount: ->
       getCompletedAmount: ->
+      getTotalAmountPerDay: ->
+      getCompletedAmountPerDay: ->
 
     spyOn(mockEditor, 'decorateMarker')
 
@@ -66,12 +68,22 @@ describe 'TodoDecorator', ->
     describe 'createWeekHoursOverlay', ->
 
     describe 'createWeekUnitOverlay', ->
+      beforeEach ->
+        spyOn(mockWeek, 'getCompletedAmountPerDay')
+        spyOn(mockWeek, 'getTotalAmountPerDay')
+        spyOn(decorator, 'createUnitDailyBreakdown')
+
       it 'calls week.getTotalAmount and section.getCompletedAmount', ->
         spyOn(mockWeek, 'getTotalAmount')
         spyOn(mockWeek, 'getCompletedAmount')
         decorator.createWeekUnitOverlay(mockWeek, 'cal')
         expect(mockWeek.getTotalAmount).toHaveBeenCalledWith('cal')
         expect(mockWeek.getCompletedAmount).toHaveBeenCalledWith('cal')
+
+      it 'calls week.getTotalAmountPerDay and getCompletedAmountPerDay with the right unit', ->
+        decorator.createWeekUnitOverlay(mockWeek, 'cal')
+        expect(mockWeek.getTotalAmountPerDay).toHaveBeenCalledWith('cal')
+        expect(mockWeek.getCompletedAmountPerDay).toHaveBeenCalledWith('cal')
 
       it 'creates an overlayElement if the section has amount of requested unit', ->
         spyOn(mockWeek, 'getTotalAmount').andReturn(2)
@@ -84,6 +96,19 @@ describe 'TodoDecorator', ->
         spyOn(mockWeek, 'getCompletedAmount').andReturn(0)
         decorator.createWeekUnitOverlay(mockWeek, 'cal')
         expect(decorator.createWeekOverlayElement).not.toHaveBeenCalled()
+
+    describe 'createUnitDailyBreakdown', ->
+      completed = total = null
+      beforeEach ->
+        completed = [1, 2, 3, 4, 5, 6, 7]
+        total = [10, 20, 30, 40, 50, 60, 70]
+
+      it 'creates the right breakdown', ->
+        testBreakDown = decorator.createUnitDailyBreakdown(total, completed, 'pants')
+        testDay = testBreakDown[3]
+        expect(testDay.day).toEqual('W')
+        expect(testDay.unitString).toEqual('4pants')
+        expect(testDay.percentage).toEqual(.1)
 
   describe 'section decoration', ->
 

--- a/spec/decorator-spec.coffee
+++ b/spec/decorator-spec.coffee
@@ -27,7 +27,7 @@ describe 'TodoDecorator', ->
 
     describe 'decorateSection', ->
       beforeEach ->
-        spyOn(decorator, 'createSectionHoursOverlay')
+        spyOn(decorator, 'createSectionHoursOverlay').andReturn({})
         spyOn(decorator, 'createSectionUnitsOverlay')
 
       it 'does not create or decorate a marker when selected unit is null', ->
@@ -35,17 +35,26 @@ describe 'TodoDecorator', ->
         expect(decorator.createMarker).not.toHaveBeenCalled()
         expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
 
+      it 'does not create or decorate a marker if no overlay element is created', ->
+        # spy createSectionUnitsOverlay returns nothing, which is what we want to test here
+        decorator.decorateSection(mockEditor, mockSection, 'pt')
+        expect(decorator.createMarker).not.toHaveBeenCalled()
+        expect(mockEditor.decorateMarker).not.toHaveBeenCalled()
+
+      it 'creates and decorates a marker if overlay element is created', ->
+        # spy createSectionHoursOverlay returns something, which is what we want to test here
+        decorator.decorateSection(mockEditor, mockSection, 'time')
+        expect(decorator.createMarker).toHaveBeenCalled()
+        expect(mockEditor.decorateMarker).toHaveBeenCalled()
+
       it 'calls createSectionHoursOverlay when selected unit is time', ->
         decorator.decorateSection(mockEditor, mockSection, 'time')
         expect(decorator.createSectionHoursOverlay).toHaveBeenCalled()
 
-      it 'calls createSectionUnitsOverlay when selected unit is pts', ->
-        decorator.decorateSection(mockEditor, mockSection, 'pts')
+      it 'calls createSectionUnitsOverlay when selected unit is something else', ->
+        decorator.decorateSection(mockEditor, mockSection, 'pt')
         expect(decorator.createSectionUnitsOverlay).toHaveBeenCalled()
-
-      it 'calls createSectionUnitsOverlay when selected unit is cal', ->
-        decorator.decorateSection(mockEditor, mockSection, 'cal')
-        expect(decorator.createSectionUnitsOverlay).toHaveBeenCalled()
+        expect(decorator.createSectionHoursOverlay).not.toHaveBeenCalled()
 
     describe 'createSectionHoursOverlay', ->
     describe 'createSectionPointsOverlay', ->

--- a/spec/markdown-atom-todo-spec.coffee
+++ b/spec/markdown-atom-todo-spec.coffee
@@ -11,6 +11,48 @@ describe "MarkdownAtomTodo", ->
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
     activationPromise = atom.packages.activatePackage('markdown-atom-todo')
+    MarkdownAtomTodo.todoMode = true
+
+  describe "cycleDayHighlight", ->
+
+    beforeEach ->
+      spyOn(MarkdownAtomTodo, 'highlightDay')
+
+    it 'does no work when not in todoMode', ->
+      MarkdownAtomTodo.todoMode = false
+
+    it 'works if in todoMode', ->
+      MarkdownAtomTodo.cycleDayHighlight()
+      expect(MarkdownAtomTodo.highlightDay).toHaveBeenCalled()
+
+    it 'cycles through the days', ->
+      days = [null, 'U', 'M', 'T', 'W', 'R', 'F', 'S']
+      expectations = ['U', 'M', 'T', 'W', 'R', 'F', 'S', null]
+      for day, index in days
+        MarkdownAtomTodo.highlightedDay = day
+        expected = expectations[index]
+        MarkdownAtomTodo.cycleDayHighlight()
+        expect(MarkdownAtomTodo.highlightDay).toHaveBeenCalledWith(expected)
+
+  describe "cycleUnitDisplay", ->
+    beforeEach ->
+      spyOn(MarkdownAtomTodo, 'displayUnit')
+
+    it 'does no work when not in todoMode', ->
+      MarkdownAtomTodo.todoMode = false
+
+    it 'works if in todoMode', ->
+      MarkdownAtomTodo.displayUnit()
+      expect(MarkdownAtomTodo.displayUnit).toHaveBeenCalled()
+
+    it 'cycles through the units', ->
+      units = [null, 'time', 'calories', 'points']
+      expectations = ['time', 'calories', 'points', null]
+      for unit, index in units
+        MarkdownAtomTodo.selectedUnit = unit
+        expected = expectations[index]
+        MarkdownAtomTodo.cycleUnitDisplay()
+        expect(MarkdownAtomTodo.displayUnit).toHaveBeenCalledWith(expected)
 
   describe "when the markdown-atom-todo:toggle event is triggered", ->
     it "hides and shows the modal panel", ->

--- a/spec/markdown-atom-todo-spec.coffee
+++ b/spec/markdown-atom-todo-spec.coffee
@@ -46,8 +46,8 @@ describe "MarkdownAtomTodo", ->
       expect(MarkdownAtomTodo.displayUnit).toHaveBeenCalled()
 
     it 'cycles through the units', ->
-      units = [null, 'time', 'calories', 'points']
-      expectations = ['time', 'calories', 'points', null]
+      units = [null, 'time', 'cal', 'pts']
+      expectations = ['time', 'cal', 'pts', null]
       for unit, index in units
         MarkdownAtomTodo.selectedUnit = unit
         expected = expectations[index]

--- a/spec/markdown-atom-todo-spec.coffee
+++ b/spec/markdown-atom-todo-spec.coffee
@@ -46,8 +46,8 @@ describe "MarkdownAtomTodo", ->
       expect(MarkdownAtomTodo.displayUnit).toHaveBeenCalled()
 
     it 'cycles through the units', ->
-      units = [null, 'time', 'cal', 'pts']
-      expectations = ['time', 'cal', 'pts', null]
+      units = [null, 'time', 'pt', 'cal']
+      expectations = ['time', 'pt', 'cal', null]
       for unit, index in units
         MarkdownAtomTodo.selectedUnit = unit
         expected = expectations[index]

--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -177,6 +177,38 @@ describe "TodoParser", ->
             testCompleted = week.getCompletedAmount('pants')
             expect(testCompleted).toEqual(13)
 
+      describe 'per day amount functions', ->
+        week = section1 = section2 = null
+        beforeEach ->
+          week = parser.parseH2Line(rowIndex, h2_valid)
+          section1 = parser.parseH3Line(rowIndex, "### project 1 ")
+          section2 = parser.parseH3Line(rowIndex, "### project 2 ")
+          week.children.push(section1)
+          week.children.push(section2)
+          spyOn(section1, 'getTotalAmountPerDay').andReturn([10, 20, 30, 40, 50, 60, 70])
+          spyOn(section1, 'getCompletedAmountPerDay').andReturn([1, 2, 3, 4, 5, 6, 7])
+
+          spyOn(section2, 'getTotalAmountPerDay').andReturn([90, 80, 70, 60, 50, 40, 30])
+          spyOn(section2, 'getCompletedAmountPerDay').andReturn([9, 8, 7, 6, 5, 4, 3])
+
+        describe 'getTotalAmountsPerDay', ->
+          it 'calls section functions with the right unit', ->
+            week.getTotalAmountPerDay('pants')
+            expect(section1.getTotalAmountPerDay).toHaveBeenCalledWith('pants')
+            expect(section2.getTotalAmountPerDay).toHaveBeenCalledWith('pants')
+          it 'adds amounts correctly', ->
+            testResult = week.getTotalAmountPerDay('pants')
+            expect(testResult).toEqual([100, 100, 100, 100, 100, 100, 100])
+
+        describe 'getCompletedAmountPerDay', ->
+          it 'calls section functions with the right unit', ->
+            week.getCompletedAmountPerDay('pants')
+            expect(section1.getCompletedAmountPerDay).toHaveBeenCalledWith('pants')
+            expect(section2.getCompletedAmountPerDay).toHaveBeenCalledWith('pants')
+          it 'adds amounts correctly', ->
+            testResult = week.getCompletedAmountPerDay('pants')
+            expect(testResult).toEqual([10, 10, 10, 10, 10, 10, 10])
+
   describe 'parseH3Line', ->
 
     describe 'with valid input', ->

--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -230,6 +230,28 @@ describe "TodoParser", ->
           testObj = sectionItem.getDoneDurationsPerDay()
           expect(testObj['F'].asHours()).toEqual((10 * 11) / 2)
 
+      describe 'Aggregate Amount Functions', ->
+        section = null
+
+        beforeEach ->
+          testTodoItems = [
+            "- M  70cal  A quick brown fox"
+            "- T  30cal  A quick brown fox"
+            "- F  50cal  DONE  A quick brown fox"
+            "- F  150cal  DONE  A quick brown fox"
+          ]
+
+          section = parser.parseH3Line(0, '### Section title')
+          for text, index in testTodoItems
+            todoItem = parser.parseTodoLine(index, text)
+            section.addTodoItem(todoItem)
+
+        it 'getTotalAmount sums childrens amount for a unit', ->
+          expect(section.getTotalAmount('cal')).toEqual(300)
+
+        it 'getCompletedAmount sums childrens completed amount for a unit', ->
+          expect(section.getCompletedAmount('cal')).toEqual(200)
+
   describe 'parseTodoLine', ->
     output = testLine = null
 

--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -320,6 +320,40 @@ describe "TodoParser", ->
         it 'getCompletedAmount sums childrens completed amount for a unit', ->
           expect(section.getCompletedAmount('cal')).toEqual(200)
 
+      describe 'AmountPerDay functions', ->
+        section = null
+        beforeEach ->
+          testTodoItems = [
+            "- T  70cal  A quick brown fox"
+            "- T  70cal  another tuesday"
+            "- W  30cal  A quick brown fox"
+            "- R  50cal  DONE  A quick brown fox"
+            "- R  50cal  DONE  another thursday"
+            "- F  150cal  DONE  A quick brown fox"
+          ]
+          section = parser.parseH3Line(0, '### Section title')
+          for text, index in testTodoItems
+            todoItem = parser.parseTodoLine(index, text)
+            section.addTodoItem(todoItem)
+
+        describe 'getTotalAmountPerDay', ->
+          it 'returns an array of 0s if requesting unit not present', ->
+            testVal = section.getTotalAmountPerDay('pants')
+            expect(testVal).toEqual([0, 0, 0, 0, 0, 0, 0])
+
+          it 'returns an array of aggregated total amounts', ->
+            testVal = section.getTotalAmountPerDay('cal')
+            expect(testVal).toEqual([0, 0, 140, 30, 100, 150, 0])
+
+        describe 'getCompletedAmountPerDay', ->
+          it 'returns an array of 0s if requesting unit not present', ->
+            testVal = section.getCompletedAmountPerDay('pants')
+            expect(testVal).toEqual([0, 0, 0, 0, 0, 0, 0])
+
+          it 'returns an array of aggregated total amounts', ->
+            testVal = section.getCompletedAmountPerDay('cal')
+            expect(testVal).toEqual([0, 0, 0, 0, 100, 150, 0])
+
   describe 'parseTodoLine', ->
     output = testLine = null
 

--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -338,6 +338,44 @@ describe "TodoParser", ->
           output = parser.parseTodoLine(1, testLine)
           expect(output.estimate).toBeNull()
 
+    describe 'amount functions', ->
+      describe 'getAmount', ->
+        describe 'pts', ->
+          it 'returns pts amount if item has pts', ->
+            todoItem = parser.parseTodoLine(0, '- T  3pt  A task for Tuesday')
+            testAmount = todoItem.getAmount('pt')
+            expect(testAmount).toEqual(3)
+
+          it 'returns 0 if item does not have pts', ->
+            todoItem = parser.parseTodoLine(0, '- T  A task for Tuesday')
+            testAmount = todoItem.getAmount('pt')
+            expect(testAmount).toEqual(0)
+
+        describe 'cal', ->
+          it 'returns cal amount if item has cal', ->
+            todoItem = parser.parseTodoLine(0, '- T  3cal  A task for Tuesday')
+            testAmount = todoItem.getAmount('cal')
+            expect(testAmount).toEqual(3)
+
+          it 'returns 0 if item does not have cal', ->
+            todoItem = parser.parseTodoLine(0, '- T  A task for Tuesday')
+            testAmount = todoItem.getAmount('cal')
+            expect(testAmount).toEqual(0)
+
+      describe 'getCompletedAmount', ->
+        it 'calls @getAmount if item is done', ->
+          todoItem = parser.parseTodoLine(0, '- T  DONE A task for Tuesday')
+          spyOn(todoItem, 'getAmount')
+          testAmount = todoItem.getCompletedAmount('pants')
+          expect(todoItem.getAmount).toHaveBeenCalledWith('pants')
+
+        it 'does not call @getAmount and returns 0 if item is not done', ->
+          todoItem = parser.parseTodoLine(0, '- T   A task for Tuesday')
+          spyOn(todoItem, 'getAmount')
+          testAmount = todoItem.getCompletedAmount('pants')
+          expect(todoItem.getAmount).not.toHaveBeenCalled()
+          expect(testAmount).toEqual(0)
+
   describe 'dateFromHeader', ->
     testOutput = null
 

--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -141,6 +141,42 @@ describe "TodoParser", ->
 
       describe 'getDoneDuration', ->
 
+      describe 'amount functions', ->
+
+        week = section1 = section2 = null
+
+        beforeEach ->
+          week = parser.parseH2Line(rowIndex, h2_valid)
+          section1 = parser.parseH3Line(rowIndex, "### project 1 ")
+          section2 = parser.parseH3Line(rowIndex, "### project 2 ")
+          week.children.push(section1)
+          week.children.push(section2)
+          spyOn(section1, 'getTotalAmount').andReturn(10)
+          spyOn(section1, 'getCompletedAmount').andReturn(3)
+
+          spyOn(section2, 'getTotalAmount').andReturn(20)
+          spyOn(section2, 'getCompletedAmount').andReturn(10)
+
+        describe 'getTotalAmount', ->
+          it 'calls getTotalAmount for each section', ->
+            week.getTotalAmount('pants')
+            expect(section1.getTotalAmount).toHaveBeenCalledWith('pants')
+            expect(section2.getTotalAmount).toHaveBeenCalledWith('pants')
+
+          it 'adds up the total amounts for its sections', ->
+            testAmount = week.getTotalAmount('pants')
+            expect(testAmount).toEqual(30)
+
+        describe 'getCompletedAmount', ->
+          it 'calls getCompletedAmount for each section', ->
+            week.getCompletedAmount('pants')
+            expect(section1.getCompletedAmount).toHaveBeenCalledWith('pants')
+            expect(section2.getCompletedAmount).toHaveBeenCalledWith('pants')
+
+          it 'adds up the completed amounts for its sections', ->
+            testCompleted = week.getCompletedAmount('pants')
+            expect(testCompleted).toEqual(13)
+
   describe 'parseH3Line', ->
 
     describe 'with valid input', ->

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -1,0 +1,9 @@
+utils = require '../lib/utils'
+
+describe 'utils', ->
+  describe 'elementSumArray', ->
+    it 'adds up two arrays element-wise', ->
+      a = [0, 1, 2]
+      b = [1, 2, 3]
+      testVal = utils.elementSumArray(a, b)
+      expect(testVal).toEqual([1, 3, 5])

--- a/styles/markdown-atom-todo.less
+++ b/styles/markdown-atom-todo.less
@@ -34,11 +34,6 @@
 
 /* This might not be the best way to do it */
 atom-text-editor::shadow{
-  .my-line-class{
-    .region{
-      background-color: @background-color-highlight;
-    }
-  }
 
   .done-badge{
     .region{


### PR DESCRIPTION
This branch adds the ability to cycle through the aggregation of units using the `ctrl-alt-cmd-u` keyboard shortcut. Now, decorations (overlays) next to weeks and sections (h2 and h3 tags) show aggregations for the selected unit. 

Units cycle on `[null, 'time', 'pt', 'cal']`
